### PR TITLE
gitsubmodules: Fixed access rights for public

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,16 @@
 [submodule "common"]
 	path = common
-	url = https://zxq.co/ripple/ripple-python-common.git
+	url = https://github.com/osuripple/ripple-python-common.git
 [submodule "secret"]
 	path = secret
-	url = git@zxq.co:ripple/lets-secret.git
+	url = https://github.com/osufx/secret.git
 [submodule "pp/oppai-ng"]
 	path = pp/oppai-ng
 	url = https://github.com/Francesco149/oppai-ng.git
 [submodule "pp/maniapp-osu-tools"]
 	path = pp/maniapp-osu-tools
-	url = git@zxq.co:ripple/maniapp-osu-tools.git
+	url = https://github.com/Francesco149/oppai-ng.git
 	branch = calc-no-replay
 [submodule "pp/catch_the_pp"]
-        path = pp/catch_the_pp
-        url = https://zxq.co/ripple/catch-the-pp.git
+  path = pp/catch_the_pp
+  url = https://github.com/light-ripple/catch-the-pp.git


### PR DESCRIPTION
Current /.gitsubmodules is using SSH for third party repositories making
is impossible to be fetched by public. This commit should fix it by
using 3rd party repositories

Signed-off-by: Jacob Hrbek <werifgx@gmail.com>