### PR TITLE
Prevent the client from re-sending failed scores

### DIFF
--- a/handlers/submitModularHandler.pyx
+++ b/handlers/submitModularHandler.pyx
@@ -559,7 +559,7 @@ class handler(requestsManager.asyncRequestHandler):
 				self.write(output)
 			else:
 				# No ranking panel, send just "ok"
-				self.write("ok")
+				self.write("error: no")
 
 			# Send username change request to bancho if needed
 			# (key is deleted bancho-side)


### PR DESCRIPTION
This PR solves the issue of failed/quit scores being duplicated. The reason for this change is that the osu client does not have a case built in for an "ok" response, meaning it is treated as a failed submit and is attempted later. This in the best scenario causes a unnecessary score submit request to be handled and at worse actual score duplication. I have manually tested this solution on my own ripple instance and have concluded it works fully. The error response tells the client to stop submitting (and doesn't display an error message for the end user).

I am aware that currently it is preferential to submit PRs through the zxq repo, however the registration on that is disabled.